### PR TITLE
docs: add index and link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -66,6 +66,9 @@ MERN-thinkboard/
 └── README.md
 ```
 
+## 📚 Documentation
+For step-by-step development notes, see the [docs](docs/README.md) directory.
+
 ---
 
 ## ⚙️ Local Development

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Documentation
+
+This folder collects step-by-step notes taken while building the MERN ThinkBoard application. Each file is prefixed with a number that reflects the order in which features were implemented.
+
+## Index
+
+- [0.Notes](0.Notes.md) – Overview of the MERN stack.
+- [1.Initial Backend](1.Initial%20Backend.md) – Initial backend setup.
+- [2.Rest API](2.Rest%20API.md) – Creating REST endpoints.
+- [3.Set Up Scripts](3.Set%20Up%20Scripts.md) – npm scripts and configuration.
+- [4.Router & Endpoint](4.Router%20%26%20Endpoint.md) – Defining routes and endpoints.
+- [5.Router Modularization](5.Router%20Modularization.md) – Splitting router into modules.
+- [6.Add gitignore](6.Add%20gitignore.md) – Managing ignored files.
+- [7.MongoDB Config](7.MongoDB%20Config.md) – Connecting to MongoDB.
+- [8.MongoDB Modules](8.MongoDB%20Modules.md) – Working with Mongoose models.
+- [9.Edit notesController](9.Edit%20notesController.md) – Updating note controller logic.
+- [10.middleware](10.middleware.md) – Middleware utilities.
+- [11.redis](11.redis.md) – Rate limiting with Redis.
+- [12.Install frontend npm](12.Install%20frontend%20npm.md) – Installing frontend dependencies.
+- [13.Create pages](13.Create%20pages.md) – Creating React pages.
+- [14.Toaster](14.Toaster.md) – Notification toaster.
+- [15.tailwindcss](15.tailwindcss.md) – Styling with TailwindCSS.
+- [16.daisyui](16.daisyui.md) – Using DaisyUI components.
+- [17.components_lucide-react](17.components_lucide-react.md) – Icons with lucide-react.
+- [18.CORS](18.CORS.md) – Configuring CORS.
+- [19.compoents_NoteCard](19.compoents_NoteCard.md) – NoteCard component.
+- [20.Homepage](20.Homepage.md) – Homepage layout.
+- [21.Global layout&poviders](21.Global%20layout%26poviders.md) – App-wide layout providers.
+- [22.CreatePage](22.CreatePage.md) – Create note page.
+- [23.utils_axios](23.utils_axios.md) – Axios utility helpers.
+- [24.DeletePage](24.DeletePage.md) – Delete page.
+- [25.NoteDetailPage](25.NoteDetailPage.md) – Note detail page.
+


### PR DESCRIPTION
## Summary
- add docs index with links to all step-by-step notes
- reference docs from main README for easier discovery

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3363506dc832ca98dc33d437bf5bb